### PR TITLE
Fix parsing when no encoding is specified

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,6 +25,9 @@ case $encoding in
   "")
     encoding="UTF-8"
     ;;
+  $pack)
+    encoding="UTF-8"
+    ;;
   "utf8")
     encoding="UTF-8"
     ;;


### PR DESCRIPTION
Cut will return the full string if there is nothing to split on, not an empty string.

Not having this means the encoding becomes the language pack, which is invalid and makes the lang impossible to find.