### PR TITLE
Handle multiple locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ You may still want to use a custom language pack though.
 
 This buildpack will use the `$LANG` environment variable, install the appropriate language pack and configure it on your app.
 
+## Multiple Locales
+
+You can request the installation of multiple locales by creating a `.locales` file and setting every locale you need, one per line.
+
 ## Installation
 
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -9,58 +9,72 @@ ENV_DIR=$3
 PROFILE_PATH="$BUILD_DIR/.profile.d/locale.sh"
 EXPORT_PATH="$BP_DIR/export"
 
-mkdir -p $BUILD_DIR/.profile.d
-export_env $ENV_DIR "." ""
-
-if [ -z $LANG ]; then
-  puts_warn "No LANG variable found. Nothing to do."
-  exit 0
-fi
-
-language=`echo $LANG | cut -d'_' -f1`
-pack=`echo $LANG | cut -d'.' -f1`
-encoding=`echo $LANG | cut -d'.' -f2`
-
-case $encoding in
-  "")
-    encoding="UTF-8"
-    ;;
-  $pack)
-    encoding="UTF-8"
-    ;;
-  "utf8")
-    encoding="UTF-8"
-    ;;
-esac
-package=language-pack-$language-base
-
-if [[ $language = "en" ]]; then
-  puts_warn "Language is $language. Nothing to install."
-  exit 0
-fi
-
-puts_step "Updating or installing $package"
-
-mkdir -p $BUILD_DIR/.heroku/locales
-
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
+APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
+mkdir -p $BUILD_DIR/.profile.d
+mkdir -p $BUILD_DIR/.heroku/locales
 mkdir -p "$APT_CACHE_DIR/archives/partial"
 mkdir -p "$APT_STATE_DIR/lists/partial"
 
-APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
+export_env $ENV_DIR "." ""
 
-apt-get $APT_OPTIONS update
-apt-get $APT_OPTIONS -y -d install --reinstall $package
+getEncoding () {
+  encoding=`echo $1 | cut -d'.' -f2`
 
+  case $encoding in
+    "")
+      encoding="UTF-8"
+      ;;
+    $pack)
+      encoding="UTF-8"
+      ;;
+    "utf8")
+      encoding="UTF-8"
+      ;;
+  esac
+  echo $encoding
+}
+
+
+if [ -n $LANG ] && ! grep -q $LANG $BUILD_DIR/.locales; then
+  echo $LANG >> $BUILD_DIR/.locales
+fi
+langs=`cat $BUILD_DIR/.locales`
+
+
+if [ ${#langs[@]} == 0 ]; then
+  puts_warn "No lang values found. Nothing to do."
+  exit 0
+fi
+
+for lang in $langs; do
+  language=`echo $lang | cut -d'_' -f1`
+  pack=`echo $lang | cut -d'.' -f1`
+  encoding=$(getEncoding $lang)
+  package=language-pack-$language-base
+
+  if [[ $language = "en" ]]; then
+    puts_warn "Language is $language. Nothing to install."
+    exit 0
+  fi
+
+  puts_step "Updating or installing $package"
+  apt-get $APT_OPTIONS update
+  apt-get $APT_OPTIONS -y -d install --reinstall $package
+
+  cat <<EOF >> $BUILD_DIR/.profile.d/000_locale.sh
+localedef -f $encoding -i $pack /app/.heroku/locales/usr/share/locale-langpack/$language/
+EOF
+done
+
+puts_step "Unpacking and configuring all locales"
 for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do
   dpkg -x $DEB $BUILD_DIR/.heroku/locales/
 done
 
-puts_step "Configuring locale with pack $pack and encoding $encoding"
-cat <<EOF >$BUILD_DIR/.profile.d/000_locale.sh
+cat <<EOF >> $BUILD_DIR/.profile.d/000_locale.sh
 export I18NPATH=/app/.heroku/locales/var/lib/locales/supported.d
-localedef -f $encoding -i $pack /app/.heroku/locales/usr/share/locale-langpack/$language/
 export LOCPATH=/app/.heroku/locales/usr/share/locale-langpack/
 EOF

--- a/fixtures/app/.locales
+++ b/fixtures/app/.locales
@@ -1,0 +1,2 @@
+de_DE
+fr_FR


### PR DESCRIPTION
This allows creating a `.locales` file in which people can set more than one locale.
I went with a file and not a config var because changing those requires a new build anyway.

cc @dzuelke 