### PR TITLE
Use break instead of exit 0 when ignoring english

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -63,7 +63,7 @@ for lang in $langs; do
 
   if [[ $language = "en" ]]; then
     puts_warn "Language is $language. Nothing to install."
-    exit 0
+    continue
   fi
 
   puts_step "Updating or installing $package"


### PR DESCRIPTION
Exiting with 0 will ignore any other locales that we want to install anyway