### PR TITLE
Append a new line to .locales before adding the default locale

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,6 +42,7 @@ if [ -n "$LANG" ]; then
   puts_warn "You should switch to a '.locales' file."
   puts_warn "See https://github.com/heroku/heroku-buildpack-locale"
 
+  test `tail -c 1 $BUILD_DIR/.locales` && echo -n "\n" >> $BUILD_DIR/.locales
   if ! grep -q $LANG $BUILD_DIR/.locales; then
     echo $LANG >> $BUILD_DIR/.locales
   fi


### PR DESCRIPTION
Unless that new line is already there.
Without this, we're breaking the locales file, as two locales would be on the same line without any delimiter.

cc @kampalex