### PR TITLE
Pin buildpack-stdlib to a specific version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-source /dev/stdin <<< "$(curl -s --retry 3 https://lang-common.s3.amazonaws.com/buildpack-stdlib/latest/stdlib.sh)"
+source /dev/stdin <<< "$(curl -s --retry 3 https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh)"
 
 BP_DIR=$(cd $(dirname $0)/..; pwd)
 BUILD_DIR=$1


### PR DESCRIPTION
To ensure that future changes to buildpack-stdlib don't cause breakage.

Using the URL form documented at:
https://github.com/heroku/buildpack-stdlib#usage

The `latest` and `v8` versions are currently equivalent, so this is a no-op in terms of functionality change:

```
$ curl -sSfI https://lang-common.s3.amazonaws.com/buildpack-stdlib/latest/stdlib.sh | rg ETag
ETag: "9f916352391c777dd280267522b6a246"
$ curl -sSfI https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh | rg ETag
ETag: "9f916352391c777dd280267522b6a246"
```