### PR TITLE
detect: don't trigger if no .locales found

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,2 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 echo "Locale"
+
+BUILD_DIR=$1
+
+if [[ -f "$BUILD_DIR/.locales" ]]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
This avoids selecting this buildpack to build unless there's actually
a .locales file in the repo.

Signed-off-by: David Caro <me@dcaro.es>
